### PR TITLE
Fix "Getting Started" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ sudo npm install -g ionic
 $ ionic start myProject tabs
 ```
 
-More info on this can be found on the Ionic [Getting Started](ionicframework.com/getting-started) page.
+More info on this can be found on the Ionic [Getting Started](http://ionicframework.com/getting-started) page.
 
 ## Installation
 


### PR DESCRIPTION
Fix "Getting Started" link to point to Ionic website and prevent it from automatically linking to internal pages in the git project.
