### PR TITLE
Fix npm deprecation warning for gulp-minify-css package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@ var gutil = require('gulp-util');
 var bower = require('bower');
 var concat = require('gulp-concat');
 var sass = require('gulp-sass');
-var minifyCss = require('gulp-minify-css');
+var cleanCss = require('gulp-clean-css');
 var rename = require('gulp-rename');
 var sh = require('shelljs');
 
@@ -18,7 +18,7 @@ gulp.task('sass', function(done) {
     .pipe(sass())
     .on('error', sass.logError)
     .pipe(gulp.dest('./www/css/'))
-    .pipe(minifyCss({
+    .pipe(cleanCss({
       keepSpecialComments: 0
     }))
     .pipe(rename({ extname: '.min.css' }))

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "gulp": "^3.5.6",
     "gulp-sass": "^2.0.4",
     "gulp-concat": "^2.2.0",
-    "gulp-minify-css": "^0.3.0",
+    "gulp-clean-css": "^2.3.0",
     "gulp-rename": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Changed gulp-minify-css package to latest gulp-clean-css as recommended in npm deprecation warning.