### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 node_modules/
 platforms/
 plugins/
+www/css/
+www/lib/
+!www/lib/ionic/


### PR DESCRIPTION
www/css should be ignore because it is generated and populted with gulp sass task, it shouldn't be pushed to repository
www/lib should be ignored too because it is populated by bower install except ionic folder that is created with the project quick starter.