### PR TITLE
Fix gulp-sass version to 3.1.0 for win32 platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An Ionic project",
   "dependencies": {
     "gulp": "^3.5.6",
-    "gulp-sass": "^2.0.4",
+    "gulp-sass": "^3.1.0",
     "gulp-concat": "^2.2.0",
     "gulp-minify-css": "^0.3.0",
     "gulp-rename": "^1.2.0"


### PR DESCRIPTION
This will fix the 404 error encountered for windows users : `Cannot download "https://github.com/sass/node-sass/releases/download/v3.13.1/win32-x64-57_binding.node`

Forcing the `gulp-sass` dependency to the current stable version (3.1.0) will naturally fix the problem. 